### PR TITLE
fix broken table on rule 238

### DIFF
--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -56,7 +56,8 @@ You *must* use these formats, whenever applicable:
 | `OpenAPI type` | `format` | Specification | Example
 | `string` | `iso-639-1`| two letter language code -- see {ISO-639-1}[ISO 639-1]. Hint: In the past we used `iso-639` as format. | `"en"`
 | `string` | `bcp47` | multi letter language tag -- see {BCP47}[BCP 47]. It is a compatible extension of {ISO-639-1}[ISO 639-1] optionally with additional information for language usage, like region, variant, script. | `"en-DE"`
-| `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]. Hint: In the past we used `iso-3166` as format. | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at ist.com `string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
+| `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]. Hint: In the past we used `iso-3166` as format. | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at ist.com
+|`string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
 | `string` | `gtin-13` | Global Trade Item Number -- see {GTIN}[GTIN] | `"5710798389878"`
 |=====================================================================
 

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -57,7 +57,7 @@ You *must* use these formats, whenever applicable:
 | `string` | `iso-639-1`| two letter language code -- see {ISO-639-1}[ISO 639-1]. Hint: In the past we used `iso-639` as format. | `"en"`
 | `string` | `bcp47` | multi letter language tag -- see {BCP47}[BCP 47]. It is a compatible extension of {ISO-639-1}[ISO 639-1] optionally with additional information for language usage, like region, variant, script. | `"en-DE"`
 | `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]. Hint: In the past we used `iso-3166` as format. | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at ist.com
-|`string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
+| `string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
 | `string` | `gtin-13` | Global Trade Item Number -- see {GTIN}[GTIN] | `"5710798389878"`
 |=====================================================================
 


### PR DESCRIPTION
Got build errors from the make command due to the broken table.
This just adds a | in the right spot to properly format the table.